### PR TITLE
Limit times shown via preference

### DIFF
--- a/extension/bootstrap.js
+++ b/extension/bootstrap.js
@@ -332,16 +332,14 @@ this.shutdown = function(data, reason) {
   // are we uninstalling?
   // if so, user or automatic?
   if (reason === REASONS.ADDON_UNINSTALL || reason === REASONS.ADDON_DISABLE) {
+    // reset the preference in case of uninstall or disable, primarily for testing
+    // purposes
+    Preferences.set("extensions.sharebuttonstudy.counter", 0);
     if (!studyUtils._isEnding) {
       // we are the first requestors, must be user action.
       studyUtils.endStudy({ reason: "user-disable" });
     }
   }
-
-  // TODO reset the counter preference value? Or delete?
-  // FIXME Make sure the addon is being uninstalled, as shutdown is also called
-  // when Firefox is quit.
-  Preferences.set("extensions.sharebuttonstudy.counter", 0);
 };
 
 this.uninstall = function(data, reason) {};

--- a/extension/bootstrap.js
+++ b/extension/bootstrap.js
@@ -97,20 +97,18 @@ class CopyController {
           shareButton.getAttribute("overflowedItem") !== "true") { // but not in the overflow menu
         // check to see if we should call a treatment at all
         const numberOfTimeShown = Preferences.get("extensions.sharebuttonstudy.counter", 0);
-        if (numberOfTimeShown >= MAX_TIMES_TO_SHOW) {
-          this.treatment = null;
-        } else {
+        if (numberOfTimeShown <= MAX_TIMES_TO_SHOW) {
           Preferences.set("extensions.sharebuttonstudy.counter", numberOfTimeShown + 1);
-        }
 
-        if (this.treatment === "ALL") {
-          Object.keys(TREATMENTS).forEach((key, index) => {
-            if (Object.prototype.hasOwnProperty.call(TREATMENTS, key)) {
-              TREATMENTS[key](this.browserWindow, shareButton);
-            }
-          });
-        } else if (this.treatment in TREATMENTS.keys()) {
-          TREATMENTS[this.treatment](this.browserWindow, shareButton);
+          if (this.treatment === "ALL") {
+            Object.keys(TREATMENTS).forEach((key, index) => {
+              if (Object.prototype.hasOwnProperty.call(TREATMENTS, key)) {
+                TREATMENTS[key](this.browserWindow, shareButton);
+              }
+            });
+          } else if (this.treatment in TREATMENTS.keys()) {
+            TREATMENTS[this.treatment](this.browserWindow, shareButton);
+          }
         }
       }
     }
@@ -341,6 +339,8 @@ this.shutdown = function(data, reason) {
   }
 
   // TODO reset the counter preference value? Or delete?
+  // FIXME Make sure the addon is being uninstalled, as shutdown is also called
+  // when Firefox is quit.
   Preferences.set("extensions.sharebuttonstudy.counter", 0);
 };
 

--- a/extension/bootstrap.js
+++ b/extension/bootstrap.js
@@ -97,7 +97,7 @@ class CopyController {
           shareButton.getAttribute("overflowedItem") !== "true") { // but not in the overflow menu
         // check to see if we should call a treatment at all
         const numberOfTimeShown = Preferences.get("extensions.sharebuttonstudy.counter", 0);
-        if (numberOfTimeShown <= MAX_TIMES_TO_SHOW) {
+        if (numberOfTimeShown < MAX_TIMES_TO_SHOW) {
           Preferences.set("extensions.sharebuttonstudy.counter", numberOfTimeShown + 1);
 
           if (this.treatment === "ALL") {

--- a/test/button_test.js
+++ b/test/button_test.js
@@ -157,7 +157,7 @@ describe("Add-on Functional Tests", function() {
   });
 
   it(`should only trigger MAX_TIMES_TO_SHOW = ${MAX_TIMES_TO_SHOW} times`, async() => {
-    // NOTE: if this test failes, make sure MAX_TIMES_TO_SHOW has the correct value.
+    // NOTE: if this test fails, make sure MAX_TIMES_TO_SHOW has the correct value.
 
     // navigate to a regular page
     driver.setContext(Context.CONTENT);


### PR DESCRIPTION
Ensures that the treatment is only shown `MAX_TIMES_TO_SHOW` times using the `extensions.sharebuttonstudy.counter` preference.