### PR TITLE
Add variations

### DIFF
--- a/extension/Config.jsm
+++ b/extension/Config.jsm
@@ -6,8 +6,9 @@ const config = {
     studyName: "share-button-study", // no spaces, for all the reasons
     variation: { }, // optional, use to override/decide;
     weightedVariations: [
-      { name: "control", weight: 1 },
-      { name: "doorhanger", weight: 1 },
+      { name: "doorhangerDoNothing", weight: 1 },
+      { name: "doorhangerAskToAdd", weight: 1 },
+      { name: "doorhangerAddToToolbar", weight: 1 },
       { name: "highlight", weight: 1 },
     ],
     /** **endings**

--- a/extension/Config.jsm
+++ b/extension/Config.jsm
@@ -5,7 +5,7 @@ const config = {
   study: {
     studyName: "share-button-study", // no spaces, for all the reasons
     variation: {
-      name: "ALL",
+      name: "doorhangerAddToToolbar", // TODO Move to Firefox preference so that we can override in testing
     }, // optional, use to override/decide
     weightedVariations: [
       { name: "control", weight: 1 },

--- a/extension/Config.jsm
+++ b/extension/Config.jsm
@@ -4,9 +4,7 @@ const EXPORTED_SYMBOLS = ["config"];
 const config = {
   study: {
     studyName: "share-button-study", // no spaces, for all the reasons
-    variation: {
-      name: "doorhangerAskToAdd", // TODO Move to Firefox preference so that we can override in testing
-    }, // optional, use to override/decide
+    variation: { }, // optional, use to override/decide;
     weightedVariations: [
       { name: "control", weight: 1 },
       { name: "doorhanger", weight: 1 },

--- a/extension/Config.jsm
+++ b/extension/Config.jsm
@@ -5,7 +5,7 @@ const config = {
   study: {
     studyName: "share-button-study", // no spaces, for all the reasons
     variation: {
-      name: "doorhangerAddToToolbar", // TODO Move to Firefox preference so that we can override in testing
+      name: "doorhangerAskToAdd", // TODO Move to Firefox preference so that we can override in testing
     }, // optional, use to override/decide
     weightedVariations: [
       { name: "control", weight: 1 },

--- a/extension/ask.css
+++ b/extension/ask.css
@@ -10,6 +10,10 @@ html {
     padding: 8px;
 }
 
+p {
+    margin: 0px;
+}
+
 .grid {
   display: grid;
   grid-template-columns: 48px 1fr;

--- a/extension/ask.css
+++ b/extension/ask.css
@@ -1,0 +1,27 @@
+@import url("chrome://global/skin/in-content/common.css");
+
+* {
+    box-sizing: border-box;
+}
+
+html {
+    overflow-y: hidden;
+    height: 96px;
+    padding: 8px;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: 48px 1fr;
+  max-width: 400px;
+  padding: 8px;
+  grid-gap: 8px;
+}
+
+.icon {
+  width: 100%
+}
+
+.only-once {
+  grid-column: 2;
+}

--- a/extension/ask.html
+++ b/extension/ask.html
@@ -1,10 +1,10 @@
- <!DOCTYPE html>
- <html lang="en"> 
+<!DOCTYPE html>
+<html lang="en">
     <head>
         <meta charset="utf-8"/>
         <title> Share Button Tooltip </title>
         <link rel="stylesheet" type="text/css"
-              href="resource://share-button-study/doorhanger.css">
+              href="resource://share-button-study/ask.css">
     </head>
     <body>
         <div class="grid">
@@ -14,8 +14,8 @@
                      width="48"/>
             </div>
             <div class="body">
-                Want to share links quickly and easily? <br>
-                Add the share button to your toolbar by clicking anywhere in this message!
+                <p> Want to share links quickly and easily? </p>
+                <p> Add the share button to your toolbar by clicking anywhere in this message! </p>
             </div>
         </div>
     </body>

--- a/extension/ask.html
+++ b/extension/ask.html
@@ -1,0 +1,22 @@
+ <!DOCTYPE html>
+ <html lang="en"> 
+    <head>
+        <meta charset="utf-8"/>
+        <title> Share Button Tooltip </title>
+        <link rel="stylesheet" type="text/css"
+              href="resource://share-button-study/doorhanger.css">
+    </head>
+    <body>
+        <div class="grid">
+            <div class="icon">
+                <img src="resource://share-button-study/share.svg"
+                     alt="share button airplane icon"
+                     width="48"/>
+            </div>
+            <div class="body">
+                Want to share links quickly and easily? <br>
+                Add the share button to your toolbar by clicking anywhere in this message!
+            </div>
+        </div>
+    </body>
+</html>

--- a/extension/bootstrap.js
+++ b/extension/bootstrap.js
@@ -124,10 +124,8 @@ function doorhangerAddToToolbarTreatment(browserWindow, shareButton) {
     CustomizableUI.addWidgetToArea("social-share-button", CustomizableUI.AREA_NAVBAR);
     // need to get using browserWindow.shareButton because the shareButton argument
     // was initialized before the button was added
-    doorhangerDoNothingTreatment(browserWindow, browserWindow.shareButton);
-  } else if (shareButtonIsUseable(shareButton)) {
-    doorhangerDoNothingTreatment(browserWindow, browserWindow.shareButton);
   }
+  doorhangerDoNothingTreatment(browserWindow, browserWindow.shareButton);
 }
 
 // define treatments as STRING: fn(browserWindow, shareButton)

--- a/extension/bootstrap.js
+++ b/extension/bootstrap.js
@@ -72,9 +72,6 @@ function doorhangerDoNothingTreatment(browserWindow, shareButton) {
 }
 
 function doorhangerAskToAddTreatment(browserWindow, shareButton) {
-  // TODO Add panel that is anchored to burger menu prompting user to add
-  // share button to toolbar.
-
   if (currentPageIsShareable(browserWindow) && !shareButtonIsUseable(shareButton)) {
     let panel = browserWindow.window.document.getElementById("share-button-ask-panel");
     if (panel === null) { // create the panel
@@ -104,6 +101,8 @@ function doorhangerAskToAddTreatment(browserWindow, shareButton) {
     const burgerMenu = browserWindow.window.document.getElementById("PanelUI-menu-button");
     // TODO What if there is no burger menu?
     if (burgerMenu !== null) {
+      // only send the telemetry ping if we actually open the panel
+      studyUtils.telemetry({ treatment: "ask-to-add" });
       panel.openPopup(burgerMenu, "bottomcenter topright", 0, 0, false, false);
     }
   } else if (shareButtonIsUseable(shareButton)) {
@@ -116,6 +115,7 @@ function doorhangerAddToToolbarTreatment(browserWindow, shareButton) {
 
   // check to see if the page will be shareable after adding the button to the toolbar
   if (currentPageIsShareable(browserWindow) && !shareButtonIsUseable(shareButton)) {
+    studyUtils.telemetry({ treatment: "add-to-toolbar" });
     CustomizableUI.addWidgetToArea("social-share-button", CustomizableUI.AREA_NAVBAR);
     // need to get using browserWindow.shareButton because the shareButton argument
     // was initialized before the button was added

--- a/extension/bootstrap.js
+++ b/extension/bootstrap.js
@@ -55,6 +55,8 @@ function doorhangerDoNothingTreatment(browserWindow, shareButton) {
 }
 
 function doorhangerAskToAddTreatment(browserWindow, shareButton) {
+  // TODO Add panel that is anchored to burger menu prompting user to add
+  // share button to toolbar.
 }
 
 function doorhangerAddToToolbarTreatment(browserWindow, shareButton) {
@@ -77,10 +79,10 @@ function highlightTreatment(browserWindow, shareButton) {
 
 // define treatments as STRING: fn(browserWindow, shareButton)
 const TREATMENTS = {
-  doorhangerDoNothing: doorhangerDoNothingTreatment,
-  doorhangerAskToAdd: doorhangerDoNothingTreatment,
+  doorhangerDoNothing:    doorhangerDoNothingTreatment,
+  doorhangerAskToAdd:     doorhangerAskToAddTreatment,
   doorhangerAddToToolbar: doorhangerAddToToolbarTreatment,
-  highlight: highlightTreatment,
+  highlight:              highlightTreatment,
 };
 
 async function chooseVariation() {

--- a/extension/bootstrap.js
+++ b/extension/bootstrap.js
@@ -40,10 +40,12 @@ function shareButtonIsUseable(shareButton) {
 }
 
 function highlightTreatment(browserWindow, shareButton) {
-  studyUtils.telemetry({ treatment: "highlight" });
-  // add the event listener to remove the css class when the animation ends
-  shareButton.addEventListener("animationend", browserWindow.animationEndListener);
-  shareButton.classList.add("social-share-button-on");
+  if (shareButtonIsUseable(shareButton)) {
+    studyUtils.telemetry({ treatment: "highlight" });
+    // add the event listener to remove the css class when the animation ends
+    shareButton.addEventListener("animationend", browserWindow.animationEndListener);
+    shareButton.classList.add("social-share-button-on");
+  }
 }
 
 function doorhangerDoNothingTreatment(browserWindow, shareButton) {

--- a/extension/bootstrap.js
+++ b/extension/bootstrap.js
@@ -75,7 +75,9 @@ function doorhangerDoNothingTreatment(browserWindow, shareButton) {
 }
 
 function doorhangerAskToAddTreatment(browserWindow, shareButton) {
-  if (currentPageIsShareable(browserWindow) && !shareButtonIsUseable(shareButton)) {
+  // check to see if we can share the page and if the share button has not yet been added
+  // if it ghas been added, we do not want to prompt to add
+  if (currentPageIsShareable(browserWindow) && shareButton === null) {
     let panel = browserWindow.window.document.getElementById("share-button-ask-panel");
     if (panel === null) { // create the panel
       panel = browserWindow.window.document.createElement("panel");

--- a/extension/bootstrap.js
+++ b/extension/bootstrap.js
@@ -404,8 +404,8 @@ this.shutdown = function(data, reason) {
   // are we uninstalling?
   // if so, user or automatic?
   if (reason === REASONS.ADDON_UNINSTALL || reason === REASONS.ADDON_DISABLE) {
-    // reset the preference in case of uninstall or disable, primarily for testing purposes
-    Preferences.set(COUNTER_PREF, 0);
+    // reset the preference in case of uninstall or disable
+    Preferences.reset(COUNTER_PREF);
     if (!studyUtils._isEnding) {
       // we are the first requestors, must be user action.
       studyUtils.endStudy({ reason: "user-disable" });

--- a/extension/bootstrap.js
+++ b/extension/bootstrap.js
@@ -104,7 +104,6 @@ function doorhangerAskToAddTreatment(browserWindow, shareButton) {
       browserWindow.window.document.getElementById("mainPopupSet").appendChild(panel);
     }
     const burgerMenu = browserWindow.window.document.getElementById("PanelUI-menu-button");
-    // TODO What if there is no burger menu?
     if (burgerMenu !== null) {
       // only send the telemetry ping if we actually open the panel
       studyUtils.telemetry({ treatment: "ask-to-add" });

--- a/extension/build-includes.txt
+++ b/extension/build-includes.txt
@@ -4,6 +4,8 @@ install.rdf
 share_button.css
 doorhanger.html
 doorhanger.css
+ask.html
+ask.css
 panel.css
 share.svg
 StudyUtils.jsm

--- a/extension/panel.css
+++ b/extension/panel.css
@@ -3,6 +3,11 @@
   height: 96px;
 }
 
-#share-button-panel > .panel-arrowcontainer > .panel-arrowcontent {
+#share-button-ask-panel {
+  width: 400px;
+  height: 96px;
+}
+
+.no-padding-panel > .panel-arrowcontainer > .panel-arrowcontent {
   padding: 0 !important;
 }

--- a/manual_test.js
+++ b/manual_test.js
@@ -22,10 +22,11 @@ const Context = firefox.Context;
     // set the treatment
     await driver.executeAsyncScript((typeArg, callback) => {
       Components.utils.import("resource://gre/modules/Preferences.jsm");
-      // using the rest parameters, treatment = args[0]
-      Preferences.set("extensions.sharebuttonstudy.treatment", typeArg);
+      if (typeArg !== null) {
+        Preferences.set("extensions.sharebuttonstudy.treatment", typeArg);
+      }
       callback();
-    }, "doorhangerAskToAdd");
+    }, null);
     // install the addon
     await utils.installAddon(driver);
 

--- a/manual_test.js
+++ b/manual_test.js
@@ -26,7 +26,7 @@ const Context = firefox.Context;
       // using the rest parameters, treatment = args[0]
       Preferences.set("extensions.sharebuttonstudy.treatment", args[0]);
       callback();
-    }, "highlight");
+    }, "doorhangerDoNothing");
     // install the addon
     await utils.installAddon(driver);
 

--- a/manual_test.js
+++ b/manual_test.js
@@ -19,6 +19,14 @@ const Context = firefox.Context;
 
     // add the share-button to the toolbar
     await utils.addShareButton(driver);
+    // set the treatment
+    await driver.executeAsyncScript((...args) => {
+      const callback = args[args.length - 1];
+      Components.utils.import("resource://gre/modules/Preferences.jsm");
+      // using the rest parameters, treatment = args[0]
+      Preferences.set("extensions.sharebuttonstudy.treatment", args[0]);
+      callback();
+    }, "highlight");
     // install the addon
     await utils.installAddon(driver);
 

--- a/manual_test.js
+++ b/manual_test.js
@@ -20,11 +20,10 @@ const Context = firefox.Context;
     // add the share-button to the toolbar
     await utils.addShareButton(driver);
     // set the treatment
-    await driver.executeAsyncScript((...args) => {
-      const callback = args[args.length - 1];
+    await driver.executeAsyncScript((typeArg, callback) => {
       Components.utils.import("resource://gre/modules/Preferences.jsm");
       // using the rest parameters, treatment = args[0]
-      Preferences.set("extensions.sharebuttonstudy.treatment", args[0]);
+      Preferences.set("extensions.sharebuttonstudy.treatment", typeArg);
       callback();
     }, "doorhangerAskToAdd");
     // install the addon

--- a/manual_test.js
+++ b/manual_test.js
@@ -26,7 +26,7 @@ const Context = firefox.Context;
       // using the rest parameters, treatment = args[0]
       Preferences.set("extensions.sharebuttonstudy.treatment", args[0]);
       callback();
-    }, "doorhangerDoNothing");
+    }, "doorhangerAskToAdd");
     // install the addon
     await utils.installAddon(driver);
 

--- a/test/button_test.js
+++ b/test/button_test.js
@@ -7,10 +7,8 @@ const assert = require("assert");
 const utils = require("./utils");
 const clipboardy = require("clipboardy");
 const webdriver = require("selenium-webdriver");
-const firefox = require("selenium-webdriver/firefox");
 
 const By = webdriver.By;
-const Context = firefox.Context;
 const until = webdriver.until;
 const MAX_TIMES_TO_SHOW = 5; // this must match MAX_TIMES_TO_SHOW in bootstrap.js
 

--- a/test/button_test.js
+++ b/test/button_test.js
@@ -44,8 +44,7 @@ async function postTestReset(driver) {
   // close the popup
   await utils.closePanel(driver);
   // reset the counter pref to 0 so that the treatment is always shown
-  await driver.executeAsyncScript((...args) => {
-    const callback = args[args.length - 1];
+  await driver.executeAsyncScript((callback) => {
     Components.utils.import("resource://gre/modules/Preferences.jsm");
     const COUNTER_PREF = "extensions.sharebuttonstudy.counter";
     if (Preferences.has(COUNTER_PREF)) {
@@ -56,11 +55,10 @@ async function postTestReset(driver) {
 }
 
 async function setTreatment(driver, treatment) {
-  return driver.executeAsyncScript((...args) => {
-    const callback = args[args.length - 1];
+  return driver.executeAsyncScript((treatmentArg, callback) => {
     Components.utils.import("resource://gre/modules/Preferences.jsm");
     // using the rest parameters, treatment = args[0]
-    Preferences.set("extensions.sharebuttonstudy.treatment", args[0]);
+    Preferences.set("extensions.sharebuttonstudy.treatment", treatmentArg);
     callback();
   }, treatment);
 }
@@ -219,6 +217,7 @@ describe("Highlight Treatment Tests", function() {
   });
 
   it("should send highlight and copy telemetry pings", async() => {
+    await utils.addShareButton(driver);
     await utils.gotoURL(driver, "http://mozilla.org");
 
     await utils.copyUrlBar(driver);

--- a/test/button_test.js
+++ b/test/button_test.js
@@ -18,22 +18,14 @@ const MAX_TIMES_TO_SHOW = 5; // this must match MAX_TIMES_TO_SHOW in bootstrap.j
 // then we can test with a clean profile every time
 
 async function regularPageAnimationTest(driver) {
-  // navigate to a regular page
-  driver.setContext(Context.CONTENT);
-  await driver.get("http://mozilla.org");
-  driver.setContext(Context.CHROME);
-
+  await utils.gotoURL(driver, "http://mozilla.org");
   await utils.copyUrlBar(driver);
   const { hasClass, hasColor } = await utils.testAnimation(driver);
   assert(hasClass && hasColor);
 }
 
 async function regularPagePopupTest(driver) {
-  // navigate to a regular page
-  driver.setContext(Context.CONTENT);
-  await driver.get("http://github.com/mozilla");
-  driver.setContext(Context.CHROME);
-
+  await utils.gotoURL(driver, "http://mozilla.org");
   await utils.copyUrlBar(driver);
   const panelOpened = await utils.testPanel(driver, "share-button-panel");
   assert(panelOpened);
@@ -127,11 +119,7 @@ describe("Basic Functional Tests", function() {
   it(`should only trigger MAX_TIMES_TO_SHOW = ${MAX_TIMES_TO_SHOW} times`, async() => {
     // NOTE: if this test fails, make sure MAX_TIMES_TO_SHOW has the correct value.
 
-    // navigate to a regular page
-    driver.setContext(Context.CONTENT);
-    await driver.get("http://mozilla.org");
-    driver.setContext(Context.CHROME);
-
+    await utils.gotoURL(driver, "http://mozilla.org");
     for (let i = 0; i < MAX_TIMES_TO_SHOW; i++) {
       /* eslint-disable no-await-in-loop */
       await utils.copyUrlBar(driver);
@@ -212,10 +200,7 @@ describe("Highlight Treatment Tests", function() {
 
   it("animation should not trigger on disabled page", async() => {
     await utils.addShareButton(driver);
-    // navigate to a disabled page
-    driver.setContext(Context.CONTENT);
-    await driver.get("about:blank");
-    driver.setContext(Context.CHROME);
+    await utils.gotoURL(driver, "about:blank");
 
     await utils.copyUrlBar(driver);
     const { hasClass, hasColor } = await utils.testAnimation(driver);
@@ -223,10 +208,7 @@ describe("Highlight Treatment Tests", function() {
   });
 
   it("animation should not trigger if the share button is not added to toolbar", async() => {
-    // navigate to a regular page
-    driver.setContext(Context.CONTENT);
-    await driver.get("http://mozilla.org");
-    driver.setContext(Context.CHROME);
+    await utils.gotoURL(driver, "http://mozilla.org");
 
     await utils.copyUrlBar(driver);
     const { hasClass, hasColor } = await utils.testAnimation(driver);
@@ -239,10 +221,7 @@ describe("Highlight Treatment Tests", function() {
   });
 
   it("should send highlight and copy telemetry pings", async() => {
-    // navigate to a regular page
-    driver.setContext(Context.CONTENT);
-    await driver.get("http://mozilla.org");
-    driver.setContext(Context.CHROME);
+    await utils.gotoURL(driver, "http://mozilla.org");
 
     await utils.copyUrlBar(driver);
     const pings = await utils.getMostRecentPingsByType(driver, "shield-study-addon");
@@ -293,10 +272,7 @@ describe("DoorhangerDoNothing Treatment Tests", function() {
 
   it("popup should not trigger on disabled page", async() => {
     await utils.addShareButton(driver);
-    // navigate to a disabled page
-    driver.setContext(Context.CONTENT);
-    await driver.get("about:blank");
-    driver.setContext(Context.CHROME);
+    await utils.gotoURL(driver, "about:blank");
 
     await utils.copyUrlBar(driver);
     const panelOpened = await utils.testPanel(driver, "share-button-panel");
@@ -305,10 +281,7 @@ describe("DoorhangerDoNothing Treatment Tests", function() {
   });
 
   it("popup should not trigger if the share button is not added to toolbar", async() => {
-    // navigate to a regular page
-    driver.setContext(Context.CONTENT);
-    await driver.get("http://mozilla.org");
-    driver.setContext(Context.CHROME);
+    await utils.gotoURL(driver, "http://mozilla.org");
 
     await utils.copyUrlBar(driver);
     const panelOpened = await utils.testPanel(driver, "share-button-panel");
@@ -321,10 +294,7 @@ describe("DoorhangerDoNothing Treatment Tests", function() {
   });
 
   it("should send doorhanger and copy telemetry pings", async() => {
-    // navigate to a regular page
-    driver.setContext(Context.CONTENT);
-    await driver.get("http://mozilla.org");
-    driver.setContext(Context.CHROME);
+    await utils.gotoURL(driver, "http://mozilla.org");
 
     await utils.copyUrlBar(driver);
     const pings = await utils.getMostRecentPingsByType(driver, "shield-study-addon");
@@ -369,10 +339,7 @@ describe("DoorhangerAskToAdd Treatment Tests", function() {
   });
 
   it("should open an ask panel on a regular page without the share button", async() => {
-    // navigate to a regular page
-    driver.setContext(Context.CONTENT);
-    await driver.get("http://mozilla.org");
-    driver.setContext(Context.CHROME);
+    await utils.gotoURL(driver, "http://mozilla.org");
 
     await utils.copyUrlBar(driver);
     const panelOpened = await utils.testPanel(driver, "share-button-ask-panel");
@@ -387,10 +354,7 @@ describe("DoorhangerAskToAdd Treatment Tests", function() {
   it("should not open an ask panel on a regular page with the share button", async() => {
     await utils.addShareButton(driver);
 
-    // navigate to a regular page
-    driver.setContext(Context.CONTENT);
-    await driver.get("http://github.com/mozilla");
-    driver.setContext(Context.CHROME);
+    await utils.gotoURL(driver, "http://mozilla.org");
 
     await utils.copyUrlBar(driver);
     const askPanelOpened = await utils.testPanel(driver, "share-button-ask-panel");
@@ -409,10 +373,7 @@ describe("DoorhangerAskToAdd Treatment Tests", function() {
   });
 
   it("should not open an ask panel on a disabled page", async() => {
-    // navigate to a disabled page
-    driver.setContext(Context.CONTENT);
-    await driver.get("about:blank");
-    driver.setContext(Context.CHROME);
+    await utils.gotoURL(driver, "about:blank");
 
     await utils.copyUrlBar(driver);
     const panelOpened = await utils.testPanel(driver, "share-button-ask-panel");
@@ -420,10 +381,7 @@ describe("DoorhangerAskToAdd Treatment Tests", function() {
   });
 
   it("should add the button to the toolbar upon clicking on ask panel", async() => {
-    // navigate to a regular page
-    driver.setContext(Context.CONTENT);
-    await driver.get("http://mozilla.org");
-    driver.setContext(Context.CHROME);
+    await utils.gotoURL(driver, "http://mozilla.org");
 
     await utils.copyUrlBar(driver);
     const panelOpened = await utils.testPanel(driver, "share-button-ask-panel");
@@ -436,10 +394,7 @@ describe("DoorhangerAskToAdd Treatment Tests", function() {
   });
 
   it("should send ask-to-add and copy telemetry pings", async() => {
-    // navigate to a regular page
-    driver.setContext(Context.CONTENT);
-    await driver.get("http://mozilla.org");
-    driver.setContext(Context.CHROME);
+    await utils.gotoURL(driver, "http://mozilla.org");
 
     await utils.copyUrlBar(driver);
     const pings = await utils.getMostRecentPingsByType(driver, "shield-study-addon");
@@ -484,10 +439,7 @@ describe("DoorhangerAddToToolbar Treatment Tests", function() {
   });
 
   it("should add the button to the toolbar upon copy paste on regular page", async() => {
-    // navigate to a regular page
-    driver.setContext(Context.CONTENT);
-    await driver.get("http://mozilla.org");
-    driver.setContext(Context.CHROME);
+    await utils.gotoURL(driver, "http://mozilla.org");
 
     await utils.copyUrlBar(driver);
     assert(await utils.promiseAddonButton(driver));
@@ -498,10 +450,7 @@ describe("DoorhangerAddToToolbar Treatment Tests", function() {
   });
 
   it("should send add-to-toolbar and copy telemetry pings", async() => {
-    // navigate to a regular page
-    driver.setContext(Context.CONTENT);
-    await driver.get("http://mozilla.org");
-    driver.setContext(Context.CHROME);
+    await utils.gotoURL(driver, "http://mozilla.org");
 
     await utils.copyUrlBar(driver);
     const pings = await utils.getMostRecentPingsByType(driver, "shield-study-addon");

--- a/test/button_test.js
+++ b/test/button_test.js
@@ -121,6 +121,31 @@ describe("Basic Functional Tests", function() {
     const clipboard = await clipboardy.read();
     assert(clipboard === testText);
   });
+
+  it(`should only trigger MAX_TIMES_TO_SHOW = ${MAX_TIMES_TO_SHOW} times`, async() => {
+    // NOTE: if this test fails, make sure MAX_TIMES_TO_SHOW has the correct value.
+
+    // navigate to a regular page
+    driver.setContext(Context.CONTENT);
+    await driver.get("http://mozilla.org");
+    driver.setContext(Context.CHROME);
+
+    for (let i = 0; i < MAX_TIMES_TO_SHOW; i++) {
+      /* eslint-disable no-await-in-loop */
+      await utils.copyUrlBar(driver);
+      // wait for the animation to end
+      await utils.waitForAnimationEnd(driver);
+      // close the popup
+      await utils.closePanel(driver);
+      /* eslint-enable no-await-in-loop */
+    }
+    // try to open the panel again, this should fail
+    await utils.copyUrlBar(driver);
+    const panelOpened = await utils.testPanel(driver);
+    const { hasClass, hasColor } = await utils.testAnimation(driver);
+
+    assert(!panelOpened && !hasClass && !hasColor);
+  });
 });
 
 describe("Highlight Treatment Tests", function() {
@@ -463,31 +488,6 @@ describe("DoorhangerAddToToolbar Treatment Tests", function() {
   });
 });
 
-//  it(`should only trigger MAX_TIMES_TO_SHOW = ${MAX_TIMES_TO_SHOW} times`, async() => {
-//    // NOTE: if this test fails, make sure MAX_TIMES_TO_SHOW has the correct value.
-//
-//    // navigate to a regular page
-//    driver.setContext(Context.CONTENT);
-//    await driver.get("http://mozilla.org");
-//    driver.setContext(Context.CHROME);
-//
-//    for (let i = 0; i < MAX_TIMES_TO_SHOW; i++) {
-//      /* eslint-disable no-await-in-loop */
-//      await utils.copyUrlBar(driver);
-//      // wait for the animation to end
-//      await utils.waitForAnimationEnd(driver);
-//      // close the popup
-//      await utils.closePanel(driver);
-//      /* eslint-enable no-await-in-loop */
-//    }
-//    // try to open the panel again, this should fail
-//    await utils.copyUrlBar(driver);
-//    const panelOpened = await utils.testPanel(driver);
-//    const { hasClass, hasColor } = await utils.testAnimation(driver);
-//
-//    assert(!panelOpened && !hasClass && !hasColor);
-//  });
-
 /*
   // These tests uninstall the addon before and install the addon after.
   // This lets us assume the addon is installed at the start of each test.
@@ -535,6 +535,4 @@ describe("New Window Add-on Functional Tests", function() {
   afterEach(async() => postTestReset(driver));
 
   it("animation should trigger on regular page", async() => regularPageAnimationTest(driver));
-
-  it("popup should trigger on regular page", async() => regularPagePopupTest(driver));
 });

--- a/test/button_test.js
+++ b/test/button_test.js
@@ -33,37 +33,59 @@ async function regularPagePopupTest(driver) {
   assert(panelOpened);
 }
 
-describe("Add-on Functional Tests", function() {
+async function overflowMenuTest(driver) {
+  const window = driver.manage().window();
+  const currentSize = await window.getSize();
+  await window.setSize(640, 480);
+  await utils.copyUrlBar(driver);
+  assert(!(await utils.testPanel(driver)));
+  await window.setSize(currentSize.width, currentSize.height);
+}
+
+async function postTestReset(driver) {
+  // wait for the animation to end before running subsequent tests
+  await utils.waitForAnimationEnd(driver);
+  // close the popup
+  await utils.closePanel(driver);
+  // reset the counter pref to 0 so that the treatment is always shown
+  await driver.executeAsyncScript((...args) => {
+    const callback = args[args.length - 1];
+    Components.utils.import("resource://gre/modules/Preferences.jsm");
+    const COUNTER_PREF = "extensions.sharebuttonstudy.counter";
+    if (Preferences.has(COUNTER_PREF)) {
+      Preferences.set(COUNTER_PREF, 0);
+    }
+    callback();
+  });
+}
+
+async function setTreatment(driver, treatment) {
+  return driver.executeAsyncScript((...args) => {
+    const callback = args[args.length - 1];
+    Components.utils.import("resource://gre/modules/Preferences.jsm");
+    // using the rest parameters, treatment = args[0]
+    Preferences.set("extensions.sharebuttonstudy.treatment", args[0]);
+    callback();
+  }, treatment);
+}
+
+describe("Basic Functional Tests", function() {
   // This gives Firefox time to start, and us a bit longer during some of the tests.
   this.timeout(15000);
 
   let driver;
-  let addonId;
 
   before(async() => {
     driver = await utils.promiseSetupDriver();
     // install the addon
-    addonId = await utils.installAddon(driver);
+    await utils.installAddon(driver);
     // add the share-button to the toolbar
     await utils.addShareButton(driver);
   });
 
   after(() => driver.quit());
 
-  afterEach(async() => {
-    // wait for the animation to end before running subsequent tests
-    await utils.waitForAnimationEnd(driver);
-    // close the popup
-    await utils.closePanel(driver);
-    // reset the counter pref to 0 so that the treatment is always shown
-    await driver.executeAsyncScript((callback) => {
-      Components.utils.import("resource://gre/modules/Preferences.jsm");
-      if (Preferences.has("extensions.sharebuttonstudy.counter")) {
-        Preferences.set("extensions.sharebuttonstudy.counter", 0);
-      }
-      callback();
-    });
-  });
+  afterEach(async() => postTestReset(driver));
 
   it("should have a URL bar", async() => {
     const urlBar = await utils.promiseUrlBar(driver);
@@ -71,7 +93,7 @@ describe("Add-on Functional Tests", function() {
     assert.equal(text, "Search or enter address");
   });
 
-  it("should have a toolbar button", async() => {
+  it("should have a share button", async() => {
     const button = await utils.promiseAddonButton(driver);
     const text = await button.getAttribute("tooltiptext");
     assert.equal(text, "Share this page");
@@ -93,31 +115,78 @@ describe("Add-on Functional Tests", function() {
     const clipboard = await clipboardy.read();
     assert(clipboard === testText);
   });
+});
 
-  it("animation should not trigger on disabled page", async() => {
-    // navigate to a disabled page
-    driver.setContext(Context.CONTENT);
-    await driver.get("about:blank");
-    driver.setContext(Context.CHROME);
+describe("Advanced Functional Tests", function() {
+  // This gives Firefox time to start, and us a bit longer during some of the tests.
+  this.timeout(15000);
 
-    await utils.copyUrlBar(driver);
-    const { hasClass, hasColor } = await utils.testAnimation(driver);
-    assert(!hasClass && !hasColor);
+  let driver;
+  let addonId;
+
+  before(async() => {
+    driver = await utils.promiseSetupDriver();
   });
 
-  it("popup should not trigger on disabled page", async() => {
-    // navigate to a regular page
-    driver.setContext(Context.CONTENT);
-    await driver.get("about:blank");
-    driver.setContext(Context.CHROME);
+  after(() => driver.quit());
 
-    await utils.copyUrlBar(driver);
-    const panelOpened = await utils.testPanel(driver);
-    assert(!panelOpened);
+  afterEach(async() => postTestReset(driver));
+
+  describe("Highlight Treatment Tests", () => {
+    before(async() => {
+      await setTreatment(driver, "highlight");
+      // install the addon
+      addonId = await utils.installAddon(driver);
+    });
+
+    after(async() => {
+      await utils.uninstallAddon(driver, addonId);
+    });
+
+    it("animation should trigger on regular page", () => regularPageAnimationTest(driver));
+
+    it("animation should not trigger on disabled page", async() => {
+      // navigate to a disabled page
+      driver.setContext(Context.CONTENT);
+      await driver.get("about:blank");
+      driver.setContext(Context.CHROME);
+
+      await utils.copyUrlBar(driver);
+      const { hasClass, hasColor } = await utils.testAnimation(driver);
+      assert(!hasClass && !hasColor);
+    });
+
+    it("should not trigger treatments if the share button is in the overflow menu", () => overflowMenuTest());
   });
 
-  it("animation should trigger on regular page", () => regularPageAnimationTest(driver));
+  describe("DoorhangerDoNothing Treatment Tests", () => {
+    before(async() => {
+      await setTreatment(driver, "doorhangerDoNothing");
+      // install the addon
+      addonId = await utils.installAddon(driver);
+    });
 
+    after(async() => {
+      await utils.uninstallAddon(driver, addonId);
+    });
+
+    it("popup should trigger on regular page", () => regularPagePopupTest(driver));
+
+    it("popup should not trigger on disabled page", async() => {
+      // navigate to a regular page
+      driver.setContext(Context.CONTENT);
+      await driver.get("about:blank");
+      driver.setContext(Context.CHROME);
+
+      await utils.copyUrlBar(driver);
+      const panelOpened = await utils.testPanel(driver);
+      assert(!panelOpened);
+    });
+
+    it("should not trigger treatments if the share button is in the overflow menu", () => overflowMenuTest());
+  });
+
+  // TODO Move the telemetry test to a helper, utils? This test file is getting crowded.
   it("should send telemetry pings for animation, doorhanger, and copy", async() => {
     // navigate to a regular page
     driver.setContext(Context.CONTENT);
@@ -145,15 +214,29 @@ describe("Add-on Functional Tests", function() {
     assert(highlightTelemetrySent && doorHangerTelemetrySent && copyTelemetrySent);
   });
 
-  it("popup should trigger on regular page", () => regularPagePopupTest(driver));
+  it(`should only trigger MAX_TIMES_TO_SHOW = ${MAX_TIMES_TO_SHOW} times`, async() => {
+    // NOTE: if this test fails, make sure MAX_TIMES_TO_SHOW has the correct value.
 
-  it("should not trigger treatments if the share button is in the overflow menu", async() => {
-    const window = driver.manage().window();
-    const currentSize = await window.getSize();
-    await window.setSize(640, 480);
+    // navigate to a regular page
+    driver.setContext(Context.CONTENT);
+    await driver.get("http://mozilla.org");
+    driver.setContext(Context.CHROME);
+
+    for (let i = 0; i < MAX_TIMES_TO_SHOW; i++) {
+      /* eslint-disable no-await-in-loop */
+      await utils.copyUrlBar(driver);
+      // wait for the animation to end
+      await utils.waitForAnimationEnd(driver);
+      // close the popup
+      await utils.closePanel(driver);
+      /* eslint-enable no-await-in-loop */
+    }
+    // try to open the panel again, this should fail
     await utils.copyUrlBar(driver);
-    assert(!(await utils.testPanel(driver)));
-    await window.setSize(currentSize.width, currentSize.height);
+    const panelOpened = await utils.testPanel(driver);
+    const { hasClass, hasColor } = await utils.testAnimation(driver);
+
+    assert(!panelOpened && !hasClass && !hasColor);
   });
 
   it(`should only trigger MAX_TIMES_TO_SHOW = ${MAX_TIMES_TO_SHOW} times`, async() => {
@@ -222,12 +305,7 @@ describe("New Window Add-on Functional Tests", function() {
 
   after(() => driver.quit());
 
-  afterEach(async() => {
-    // wait for the animation to end before running subsequent tests
-    await utils.waitForAnimationEnd(driver);
-    // close the popup
-    await utils.closePanel(driver);
-  });
+  afterEach(async() => postTestReset(driver));
 
   it("animation should trigger on regular page", async() => regularPageAnimationTest(driver));
 

--- a/test/utils.js
+++ b/test/utils.js
@@ -206,9 +206,9 @@ module.exports.closePanel = async(driver) => {
 // first element is most recent ping
 // as seen in shield-study-addon-util's `utils.jsm`
 module.exports.getMostRecentPingsByType = async(driver, type) =>
-  driver.executeAsyncScript(async() => {
-    const typeArg = arguments[0];
-    const callback = arguments[arguments.length - 1];
+  driver.executeAsyncScript(async(...args) => {
+    const typeArg = args[0];
+    const callback = args[args.length - 1];
 
     Components.utils.import("resource://gre/modules/TelemetryArchive.jsm");
     const pings = await TelemetryArchive.promiseArchivedPingList();

--- a/test/utils.js
+++ b/test/utils.js
@@ -196,9 +196,8 @@ module.exports.testPanel = async(driver, panelId) => {
   try { // if we can't find the panel, return false
     return await driver.wait(async() => {
       // need to execute JS, since state is not an HTML attribute, it's a property
-      const panelState = await driver.executeAsyncScript((...args) => {
-        const callback = args[args.length - 1];
-        const shareButtonPanel = window.document.getElementById(args[0]);
+      const panelState = await driver.executeAsyncScript((panelIdArg, callback) => {
+        const shareButtonPanel = window.document.getElementById(panelIdArg);
         if (shareButtonPanel === null) {
           callback(null);
         } else {
@@ -223,10 +222,7 @@ module.exports.closePanel = async(driver) => {
 // first element is most recent ping
 // as seen in shield-study-addon-util's `utils.jsm`
 module.exports.getMostRecentPingsByType = async(driver, type) =>
-  driver.executeAsyncScript(async(...args) => {
-    const typeArg = args[0];
-    const callback = args[args.length - 1];
-
+  driver.executeAsyncScript(async(typeArg, callback) => {
     Components.utils.import("resource://gre/modules/TelemetryArchive.jsm");
     const pings = await TelemetryArchive.promiseArchivedPingList();
 

--- a/test/utils.js
+++ b/test/utils.js
@@ -237,3 +237,10 @@ module.exports.getMostRecentPingsByType = async(driver, type) =>
 
     callback(await Promise.all(pingData));
   }, type);
+
+module.exports.gotoURL = async(driver, url) => {
+  // navigate to a regular page
+  driver.setContext(Context.CONTENT);
+  await driver.get(url);
+  driver.setContext(Context.CHROME);
+};

--- a/test/utils.js
+++ b/test/utils.js
@@ -71,6 +71,22 @@ module.exports.addShareButton = async driver =>
     callback();
   });
 
+module.exports.removeShareButton = async(driver) => {
+  try {
+    return driver.executeAsyncScript((callback) => {
+      Components.utils.import("resource:///modules/CustomizableUI.jsm");
+      CustomizableUI.removeWidgetFromArea("social-share-button");
+      callback();
+    });
+  } catch (e) {
+    if (e.type === "StaleElementReferenceError") {
+      console.log(e.msg); // eslint-disable-line no-console
+      return null;
+    }
+    throw (e);
+  }
+};
+
 module.exports.installAddon = async(driver) => {
   // references:
   //    https://bugzilla.mozilla.org/show_bug.cgi?id=1298025

--- a/test/utils.js
+++ b/test/utils.js
@@ -191,20 +191,21 @@ module.exports.takeScreenshot = async(driver) => {
   }
 };
 
-module.exports.testPanel = async(driver) => {
+module.exports.testPanel = async(driver, panelId) => {
   driver.setContext(Context.CHROME);
   try { // if we can't find the panel, return false
     return await driver.wait(async() => {
       // need to execute JS, since state is not an HTML attribute, it's a property
-      const panelState = await driver.executeAsyncScript((callback) => {
-        const shareButtonPanel = window.document.getElementById("share-button-panel");
+      const panelState = await driver.executeAsyncScript((...args) => {
+        const callback = args[args.length - 1];
+        const shareButtonPanel = window.document.getElementById(args[0]);
         if (shareButtonPanel === null) {
           callback(null);
         } else {
           const state = shareButtonPanel.state;
           callback(state);
         }
-      });
+      }, panelId);
       return panelState === "open";
     }, 3000);
   } catch (e) {


### PR DESCRIPTION
~~**NOTE**: This branch is a result of merging #31 `make-it-a-shield-study` and #32 `limit-times-shown-via-pref`.~~

**NOTE**: Tests may fail as there are changes in functionality.

Variations are centered on adding aggressiveness of adding button to toolbar.
1. If the share button is not in the toolbar, then don’t do anything upon URL bar copy.
2. If the share button is not in the toolbar, then upon URL bar copy ask to move the share button study to the toolbar (with a panel on burger menu or page action on URL bar).
3. If the share button is not in the toolbar, then move to the toolbar without asking.
It’s important to keep track of which case and what we did so we can undo this change after the study is over (?).